### PR TITLE
Order 이슈 구현

### DIFF
--- a/order/src/main/java/com/vroong/order/adapter/in/message/MessageConsumer.java
+++ b/order/src/main/java/com/vroong/order/adapter/in/message/MessageConsumer.java
@@ -1,6 +1,7 @@
 package com.vroong.order.adapter.in.message;
 
 import com.vroong.order.application.EventHandlerFactory;
+import com.vroong.order.config.Constants.MessageKey;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +19,8 @@ public class MessageConsumer implements Consumer<Message<?>> {
   public void accept(Message<?> message) {
     log.info("A message received: {}", new String((byte[]) message.getPayload()));
 
-    final String topicName = String.valueOf(message.getHeaders().get("kafka_receivedTopic"));
+    final String source = String.valueOf(message.getHeaders().get(MessageKey.SOURCE));
 
-    eventHandlerFactory.createFor(topicName).handle(message);
+    eventHandlerFactory.createFor(source).handle(message);
   }
 }

--- a/order/src/main/java/com/vroong/order/application/EventHandlerFactory.java
+++ b/order/src/main/java/com/vroong/order/application/EventHandlerFactory.java
@@ -1,8 +1,9 @@
 package com.vroong.order.application;
 
+import static com.vroong.order.config.Constants.DELIVERY_PROJECT_NAME;
+import static com.vroong.order.config.Constants.PAYMENT_PROJECT_NAME;
+
 import com.vroong.order.application.port.in.EventHandler;
-import com.vroong.order.config.ApplicationProperties;
-import com.vroong.order.config.ApplicationProperties.Kafka.Topic;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,28 +12,22 @@ public class EventHandlerFactory {
   private final EventHandler idempotentDeliveryEventHandler;
   private final EventHandler idempotentPaymentEventHandler;
 
-  private final ApplicationProperties properties;
-
   public EventHandlerFactory(
       EventHandler idempotentDeliveryEventHandler,
-      EventHandler idempotentPaymentEventHandler,
-      ApplicationProperties properties
+      EventHandler idempotentPaymentEventHandler
   ) {
     this.idempotentDeliveryEventHandler = idempotentDeliveryEventHandler;
     this.idempotentPaymentEventHandler = idempotentPaymentEventHandler;
-    this.properties = properties;
   }
 
-  public EventHandler createFor(String topicName) {
-    final Topic topic = properties.getKafka().getTopic();
-
-    if (topicName.equals(topic.getDelivery())) {
+  public EventHandler createFor(String source) {
+    if (source.equals(DELIVERY_PROJECT_NAME)) {
       return idempotentDeliveryEventHandler;
     }
-    if (topicName.equals(topic.getPayment())) {
+    if (source.equals(PAYMENT_PROJECT_NAME)) {
       return idempotentPaymentEventHandler;
     }
 
-    throw new IllegalArgumentException("등록되지 않은 토픽입니다: " + topicName);
+    throw new IllegalArgumentException("등록되지 않은 서비스입니다: " + source);
   }
 }

--- a/order/src/main/java/com/vroong/order/application/OrderService.java
+++ b/order/src/main/java/com/vroong/order/application/OrderService.java
@@ -57,7 +57,7 @@ public class OrderService implements OrderUsecase {
   @Transactional(readOnly = true)
   public Order getOrder(Long orderId) {
     final Order order = orderRepository.getReferenceById(orderId);
-    if (!getCurrentUsername().equals(order.getCreatedBy())) {
+    if (!SecurityUtils.isClientIdInternal() && !getCurrentUsername().equals(order.getCreatedBy())) {
       throw new IllegalArgumentException("자신의 주문만 조회할 수 있습니다.");
     }
 

--- a/order/src/main/java/com/vroong/order/config/Constants.java
+++ b/order/src/main/java/com/vroong/order/config/Constants.java
@@ -33,6 +33,9 @@ public class Constants {
   public static final String PRODUCER_CHANNEL = "messageProducer-out-0";
   public static final String CONSUMER_CHANNEL = "messageConsumer-in-0";
 
+  public static final String PAYMENT_PROJECT_NAME = "payment";
+  public static final String DELIVERY_PROJECT_NAME = "delivery";
+
   /**
    * MessageSchema spec: @see https://wiki.mm.meshkorea.net/display/MES/Message+Schema
    */

--- a/order/src/main/java/com/vroong/order/support/SecurityUtils.java
+++ b/order/src/main/java/com/vroong/order/support/SecurityUtils.java
@@ -62,4 +62,16 @@ public class SecurityUtils {
             .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(authority)))
         .orElse(false);
   }
+
+  public static boolean isClientIdInternal() {
+    final SecurityContext securityContext = SecurityContextHolder.getContext();
+    final Object principal = securityContext.getAuthentication().getPrincipal();
+    if (principal instanceof Jwt jwt) {
+      final String clientId = String.valueOf(jwt.getClaims().get("client_id"));
+
+      return clientId.equals("internal");
+    }
+
+    return false;
+  }
 }

--- a/order/src/test/java/com/vroong/order/WithMockJwt.java
+++ b/order/src/test/java/com/vroong/order/WithMockJwt.java
@@ -1,0 +1,18 @@
+package com.vroong.order;
+
+import com.vroong.order.WithMockJwtSecurityContextFactory.AuthoritiesType;
+import com.vroong.order.WithMockJwtSecurityContextFactory.ClientIdType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockJwtSecurityContextFactory.class)
+public @interface WithMockJwt {
+
+  String username() default "user";
+
+  ClientIdType clientId() default ClientIdType.WEB_APP;
+
+  AuthoritiesType[] authorities() default {AuthoritiesType.ROLE_USER};
+}

--- a/order/src/test/java/com/vroong/order/WithMockJwtSecurityContextFactory.java
+++ b/order/src/test/java/com/vroong/order/WithMockJwtSecurityContextFactory.java
@@ -1,0 +1,66 @@
+package com.vroong.order;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockJwtSecurityContextFactory implements WithSecurityContextFactory<WithMockJwt> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockJwt annotation) {
+    final SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+    final String username = annotation.username();
+    final String clientId = annotation.clientId().getValue();
+    final List<String> authorities = Arrays.stream(annotation.authorities())
+        .map(Enum::name)
+        .toList();
+
+    final Instant issuedAt = Instant.now();
+    final Instant expiresAt = issuedAt.plusSeconds(3600L);
+    final Jwt jwt = new Jwt(
+        "test token",
+        issuedAt,
+        expiresAt,
+        Map.of("typ", "JWT"),
+        Map.of(
+            "user_name", username,
+            "scope", "openid",
+            "exp", expiresAt,
+            "iat", issuedAt,
+            "authorities", authorities,
+            "jti", UUID.randomUUID(),
+            "client_id", clientId
+        )
+    );
+
+    final JwtAuthenticationToken jwtAuthenticationToken = new JwtAuthenticationToken(jwt);
+
+    context.setAuthentication(jwtAuthenticationToken);
+    return context;
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ClientIdType {
+    WEB_APP("web_app"),
+    INTERNAL("internal");
+
+    private final String value;
+  }
+
+  public enum AuthoritiesType {
+    ROLE_USER,
+    ROLE_ADMIN,
+    ROLE_ANONYMOUS
+  }
+}


### PR DESCRIPTION
https://github.com/meshkorea/springbootcamp/issues/10
위 이슈에 해당하는 내용을 구현했습니다
- [order] EventHandlerFactory에서 메시지의 messageSource 헤더를 사용하도록 변경
- [order] getOrder: 요청자가 서비스(internal)인지 사용자인지 구분하여 동작 + 테스트 코드는 @WithMockJwt 애너테이션을 만들어서 작성했습니다
- master 리베이스